### PR TITLE
Remove unnecessary console.log in summarize function

### DIFF
--- a/lib/summarize.js
+++ b/lib/summarize.js
@@ -43,7 +43,6 @@ module.exports = async (opts) => {
   const { $, text } = createDocument(opts)
   const titleNorm = (title && normalizeSentence(title))
 
-  console.log(text)
   const rawSentences = tokenizeSentences(text)
     .map((s) => normalizeSentence(s))
 


### PR DESCRIPTION
When using the summarize function the text to be summarized gets printed on stdout. This behavior is not ideal for a production environment.